### PR TITLE
Change type of value inside package_data to be list of string, not string

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email = "jonathan.robie@biblicalhumanities.org",
     packages = ["greeksyntax"],
     package_data = {
-	"greeksyntax" : "greeksyntax/*.css",
+	"greeksyntax" : ["greeksyntax/*.css"],
     },
     install_requires=[
           'BaseXClient',


### PR DESCRIPTION
Apparently this is required for some versions of setuptools.